### PR TITLE
AndroidManifest.xml: remove minSdk to build project successful and ta…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,10 +5,6 @@
     android:versionCode="201603162"
     android:versionName="1.0">
 
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="21" />
-
     <uses-permission android:name="android.permission.DUMP"/>
 
     <application


### PR DESCRIPTION
Building from command line fails due to minSdk is not allowed on AndroidManifest.xml

![Screenshot_20230120_202540](https://user-images.githubusercontent.com/64617882/213778767-eaf97d62-8d99-43aa-b3fc-5ecac3774e4a.png)

This should be a fix for it.